### PR TITLE
Corrections to Dex/Drms switching

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticGroundMotionSimulation"
 uuid = "b8c06d6b-f458-43ac-b37a-3e779b88779f"
 authors = ["Peter Stafford <p.stafford@me.com>"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/duration/PJSduration.jl
+++ b/src/duration/PJSduration.jl
@@ -156,7 +156,7 @@ Boore & Thompson (2012) rms duration model. Also outputs the excitation duration
 function boore_thompson_2012(m, r_ps::T, src::SourceParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {T<:Real}
   # for magnitude and distance that don't match coefficient tables we need to use bilinear interpolation
   # get the excitation duration (as recommended by Boore & Thompson, 2012)
-  Dex = boore_thompson_2014(m, r_ps, src)
+  Dex = excitation_duration(m, r_ps, src, rvt)
   # get the oscillator period
   T_n = period(sdof)
   ζ = sdof.ζ_n
@@ -287,7 +287,7 @@ Boore & Thompson (2015) rms duration model. Also outputs the excitation duration
 function boore_thompson_2015(m, r_ps::T, src::SourceParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {T<:Real}
   # for magnitude and distance that don't match coefficient tables we need to use bilinear interpolation of the log Drms values
   # get the excitation duration (as recommended by Boore & Thompson, 2015)
-  Dex = boore_thompson_2014(m, r_ps, src)
+  Dex = excitation_duration(m, r_ps, src, rvt)
   # get the oscillator period
   T_n = period(sdof)
   ζ = sdof.ζ_n
@@ -379,16 +379,17 @@ boore_thompson_2015(m, r_ps, fas::FourierParameters, sdof::Oscillator, rvt::Rand
     rms_duration(m::S, r_ps::T, src::SourceParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {T<:Real}
 
 Returns a 3-tuple of (Drms, Dex, Dratio), using a switch on `rvt.dur_rms`.
-Default `:BT12` makes use of the `:BT14` model for excitation duration, `Dex`.
+Default `rvt` makes use of the `:BT14` model for excitation duration, `Dex`.
 - `m` is magnitude
 - `r_ps` is an equivalent point source distance
 """
 function rms_duration(m, r_ps::T, src::SourceParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {T<:Real}
-  if rvt.dur_rms == :BT15
+  if (rvt.dur_rms == :BT15) && (rvt.pf_method == :DK80)
     return boore_thompson_2015(m, r_ps, src, sdof, rvt)
-  elseif rvt.dur_rms == :BT12
+  elseif (rvt.dur_rms == :BT12) && (rvt.pf_method == :CL56) 
     return boore_thompson_2012(m, r_ps, src, sdof, rvt)
   else
+    println("Inconsistent combination of `rvt.dur_rms` and `rvt.pf_method`")
     return (T(NaN), T(NaN), T(NaN))
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -788,6 +788,19 @@ using LinearAlgebra
         @test Dexf == Dexd.value
         @test Dratiof == Dratiod.value
 
+
+        rvt = RandomVibrationParameters(:CL56, :BT14, :BT12, :WNA)
+        Drmsf, Dexf, Dratiof = rms_duration(m, r, fasf, sdof, rvt)
+        Drmsf1, Dexf1, Dratiof1 = StochasticGroundMotionSimulation.boore_thompson_2012(m, r, fasf, sdof, rvt)
+
+        @test Drmsf == Drmsf1
+        @test Dexf == Dexf1
+        @test Dratiof == Dratiof1
+
+        @test isnan(StochasticGroundMotionSimulation.boore_thompson_2015(m, -1.0, srcf))
+        @test isnan(StochasticGroundMotionSimulation.boore_thompson_2015(m, -1.0, srcd))
+        @test isnan(StochasticGroundMotionSimulation.boore_thompson_2015(m, -1.0, SourceParameters(1)))
+
         # Boore & Thompson 2014
         m = 6.0
         fa, fb, ε = corner_frequency(m, src)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -672,7 +672,7 @@ using LinearAlgebra
         rvt_acr = RandomVibrationParameters(:DK80, :BT14, :BT15, :WNA)
         rvt_scr = RandomVibrationParameters(:DK80, :BT15, :BT15, :ENA)
         for i in 1:length(rti)
-            if ( rti[i] < 17.0 ) | ( rti[i] > 281.0 )
+            if (rti[i] < 17.0) | (rti[i] > 281.0)
                 @test excitation_duration(m, rti[i], src, rvt_scr) .<= excitation_duration(m, rti[i], src, rvt_acr)
             else
                 @test excitation_duration(m, rti[i], src, rvt_scr) .> excitation_duration(m, rti[i], src, rvt_acr)
@@ -760,7 +760,18 @@ using LinearAlgebra
         Drms, Dex, Dratio = StochasticGroundMotionSimulation.boore_thompson_2012(m, r, fas, sdof, rvt)
         Dex0 = StochasticGroundMotionSimulation.boore_thompson_2014(m, r, fas)
 
+        @test Dex != Dex0
+
+        rvt = RandomVibrationParameters(:CL56, :BT14, :BT12, :WNA)
+        Drms, Dex, Dratio = StochasticGroundMotionSimulation.boore_thompson_2012(m, r, fas, sdof, rvt)
+        Dex0 = StochasticGroundMotionSimulation.boore_thompson_2014(m, r, fas)
+
         @test Dex == Dex0
+
+        rvt = RandomVibrationParameters(:DK80, :BT14, :BT12, :WNA)
+        Drms, Dex, Dratio = rms_duration(m, r, fas, sdof, rvt)
+
+        @test isnan(Dex)
 
         # @code_warntype rms_duration(m, r, srcf, path, sdof, rvt)
         # @code_warntype rms_duration(m, r, srcd, path, sdof, rvt)
@@ -769,6 +780,7 @@ using LinearAlgebra
 
         # @time Drmsf, Dexf, Dratiof = rms_duration(m, r, fasf, sdof, rvt)
         # @time Drmsd, Dexd, Dratiod = rms_duration(m, r, fasd, sdof, rvt)
+        rvt = RandomVibrationParameters()
         Drmsf, Dexf, Dratiof = rms_duration(m, r, fasf, sdof, rvt)
         Drmsd, Dexd, Dratiod = rms_duration(m, r, fasd, sdof, rvt)
 


### PR DESCRIPTION
Previously the incorrect excitation duration could be computed within an rms duration calculation