### PR TITLE
Extensive changes to handling of spectral moments

### DIFF
--- a/docs/src/random_vibration_parameters.md
+++ b/docs/src/random_vibration_parameters.md
@@ -44,6 +44,8 @@ where ``\psi`` is the peak factor computed from `peak_factor`, ``m_0`` is the ze
 The main methods used to interact with `RandomVibrationParameters` are:
 
 ```@docs
+SpectralMoments
+create_spectral_moments
 spectral_moment
 spectral_moments
 spectral_moments_gk

--- a/src/StochasticGroundMotionSimulation.jl
+++ b/src/StochasticGroundMotionSimulation.jl
@@ -19,6 +19,8 @@ export Oscillator,
 	PathParameters,
 	SiteParameters,
 	RandomVibrationParameters,
+	SpectralMoments,
+	create_spectral_moments,
     period,
     transfer,
     transfer!,
@@ -55,6 +57,7 @@ export Oscillator,
 # Write your package code here.
 include("oscillator/PJSoscillator.jl")
 include("fourier/PJSfourierParameters.jl")
+include("rvt/PJSspectralMoments.jl")
 include("rvt/PJSrandomVibrationParameters.jl")
 include("fourier/PJSsite.jl")
 include("fourier/PJSsource.jl")

--- a/src/duration/PJSduration.jl
+++ b/src/duration/PJSduration.jl
@@ -508,9 +508,9 @@ function liu_pezeshk_1999(m, r_ps::T, fas::FourierParameters, sdof::Oscillator, 
   γ = Dex / Dosc
   # spectral moments, required for use within definition of α parameter
   mi = spectral_moments([0,1,2], m, r_ps, fas, sdof)
-  m0 = mi[1]
-  m1 = mi[2]
-  m2 = mi[3]
+  m0 = mi.m0
+  m1 = mi.m1
+  m2 = mi.m2
   # define α
   α = sqrt( 2π * (1.0 - ( m1^2 )/( m0*m2 )) )
   n = 2.0

--- a/src/rvt/PJSpeakFactor.jl
+++ b/src/rvt/PJSpeakFactor.jl
@@ -37,13 +37,12 @@ function peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 
 	int_sum = dfac * dot( wi, integrand.(zi) )
 
-	pf = sqrt(2.0) * int_sum
-	return pf
+	return sqrt(2.0) * int_sum
 end
 
 
 @doc raw"""
-	peak_factor_cl56(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator; nodes::Int=35) where {S<:Real,T<:Real,U<:Real,V<:Real}
+	peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:Real}
 
 Peak factor computed using the Cartwright and Longuet-Higgins (1956) formulation, using pre-computed `Dex` and `m0` values.
 
@@ -57,11 +56,11 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_dk80`](@ref)
 """
-function peak_factor_cl56(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator; nodes::Int=35) where {S<:Real,T<:Real,U<:Real,V<:Real}
+function peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:Real}
 	# get all necessary spectral moments
-	mi = spectral_moments([2, 4], m, r_ps, fas, sdof)
-	m2 = mi[1]
-	m4 = mi[2]
+	m0 = mi.m0
+	m2 = mi.m2
+	m4 = mi.m4
 	# get the peak factor
 	n_z = Dex * sqrt( m2 / m0 ) / π
 	n_e = Dex * sqrt( m4 / m2 ) / π
@@ -84,8 +83,7 @@ function peak_factor_cl56(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, 
 
 	int_sum = dfac * dot( wi, integrand.(zi) )
 
-	pf = sqrt(2.0) * int_sum
-	return pf
+	return sqrt(2.0) * int_sum
 end
 
 
@@ -224,9 +222,9 @@ See also: [`peak_factor`](@ref), [`peak_factor_cl56`](@ref)
 function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=30) where {S<:Real,T<:Real}
 	# compute first three spectral moments
 	mi = spectral_moments([0, 1, 2], m, r_ps, fas, sdof)
-	m0 = mi[1]
-	m1 = mi[2]
-	m2 = mi[3]
+	m0 = mi.m0
+	m1 = mi.m1
+	m2 = mi.m2
 
 	# bandwidth, and effective bandwidth
 	δ = sqrt( 1.0 - (m1^2 / (m0*m2)) )
@@ -250,12 +248,12 @@ function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 	# evaluate integrand
 	yy = vanmarcke_ccdf.(zi, n_z, δeff)
 
-	return int_sum = dfac * dot( wi, yy )
+	return dfac * dot( wi, yy )
 end
 
 
 @doc raw"""
-	peak_factor_dk80(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator; nodes::Int=30) where {S<:Real,T<:Real,U<:Real,V<:Real}
+	peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:Real}
 
 Peak factor computed using the Der Kiureghian (1980)/Vanmarcke (1975) formulation, using precomputed `Dex` and `m0`.
 
@@ -277,11 +275,11 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_cl56`](@ref)
 """
-function peak_factor_dk80(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator; nodes::Int=30) where {S<:Real,T<:Real,U<:Real,V<:Real}
+function peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:Real}
 	# compute first three spectral moments
-	mi = spectral_moments([1, 2], m, r_ps, fas, sdof)
-	m1 = mi[1]
-	m2 = mi[2]
+	m0 = mi.m0
+	m1 = mi.m1
+	m2 = mi.m2
 
 	# bandwidth, and effective bandwidth
 	δ = sqrt( 1.0 - (m1^2 / (m0*m2)) )
@@ -303,7 +301,7 @@ function peak_factor_dk80(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, 
 	# evaluate integrand
 	yy = vanmarcke_ccdf.(zi, n_z, δeff)
 
-	return int_sum = dfac * dot( wi, yy )
+	return dfac * dot( wi, yy )
 end
 
 
@@ -333,9 +331,9 @@ See also: [`peak_factor`](@ref), [`peak_factor_dk80`](@ref), [`peak_factor_cl56`
 function peak_factor_dk80_gk(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Float64,T<:Real}
 	# compute first three spectral moments
 	mi = spectral_moments([0, 1, 2], m, r_ps, fas, sdof)
-	m0 = mi[1]
-	m1 = mi[2]
-	m2 = mi[3]
+	m0 = mi.m0
+	m1 = mi.m1
+	m2 = mi.m2
 
 	# bandwidth, and effective bandwidth
 	δ = sqrt( 1.0 - (m1^2 / (m0*m2)) )
@@ -356,10 +354,10 @@ end
 
 
 @doc raw"""
-	peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; pf_method::Symbol=:DK80) where {S<:Real,T<:Real}
+	peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
 
 Peak factor ``u_{max} / u_{rms}`` with a switch of `pf_method` to determine the approach adopted.
-`pf_method` can currently be one of:
+`rvt.pf_method` can currently be one of:
 	- `:CL56` for Cartright Longuet-Higgins (1956)
 	- `:DK80` for Der Kiureghian (1980), building on Vanmarcke (1975)
 
@@ -378,7 +376,7 @@ end
 
 
 """
-	peak_factor(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Real,V<:Real}
+	peak_factor(Dex::U, m0::V, rvt::RandomVibrationParameters) where {U<:Real}
 
 Peak factor u_max / u_rms with a switch of `pf_method` to determine the approach adopted.
 `pf_method` can currently be one of:
@@ -387,18 +385,12 @@ Peak factor u_max / u_rms with a switch of `pf_method` to determine the approach
 
 Defaults to `:DK80`.
 """
-function peak_factor(m::S, r_ps::T, Dex::U, m0::V, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Real,V<:Real}
+function peak_factor(Dex::U, mi::SpectralMoments, rvt::RandomVibrationParameters) where {U<:Real}
 	if rvt.pf_method == :CL56
-		return peak_factor_cl56(m, r_ps, Dex, m0, fas, sdof)
+		return peak_factor_cl56(Dex, mi)
 	elseif rvt.pf_method == :DK80
-		return peak_factor_dk80(m, r_ps, Dex, m0, fas, sdof)
+		return peak_factor_dk80(Dex, mi)
 	else
-		if S <: Dual
-			return S(NaN)
-		elseif V <: Dual
-			return V(NaN)
-		else
-			return U(NaN)
-		end
+		return U(NaN)
 	end
 end

--- a/src/rvt/PJSrandomVibration.jl
+++ b/src/rvt/PJSrandomVibration.jl
@@ -1,154 +1,4 @@
 
-@doc raw"""
-	spectral_moment(order::Int, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
-
-Compute spectral moment of a specified order.
-
-Evaluates the expression:
-```math
-	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
-```
-where ``k`` is the order of the moment.
-
-Integration is performed using Gauss-Legendre integration using `nodes` nodes and weights.
-The integration domain is partitioned over the `control_freqs` as well as two inserted frequencies at `f_n/1.5` and `f_n*1.5` in order to ensure good approximation of the integral around the `sdof` resonant frequency.
-
-See also: [`spectral_moments`](@ref)
-"""
-function spectral_moment(order::Int, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
-	# pre-allocate for squared fourier amplitude spectrum
-	if S <: Dual
-		Af2 = Vector{S}(undef, nodes)
-		Hf2 = Vector{S}(undef, nodes)
-		int_sum = zero(S)
-	else
-		U = get_parametric_type(fas)
-		Af2 = Vector{U}(undef, nodes)
-		Hf2 = Vector{U}(undef, nodes)
-		int_sum = zero(U)
-	end
-	# partition the integration domain to make sure the integral captures the key change in the integrand
-	f_n = sdof.f_n
-	# note that we start slightly above zero to avoid a numerical issue with the frequency dependent Q(f) gradients
-	fidLO = findall(control_freqs .< f_n/1.5)
-	fidHI = findall(control_freqs .> f_n*1.5)
-	# perform the integration with a logarithmic transformation
-	lnflims = log.([ control_freqs[fidLO]; f_n/1.5; f_n*1.5; control_freqs[fidHI] ])
-
-	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
-
-	for i in 2:lastindex(lnflims)
-		@inbounds dfac = (lnflims[i]-lnflims[i-1])/2
-		@inbounds pfac = (lnflims[i]+lnflims[i-1])/2
-		lnfi = @. dfac * xi + pfac
-		fi = exp.(lnfi)
-		squared_transfer!(Hf2, fi, sdof)
-		squared_fourier_spectrum!(Af2, fi, m, r_ps, fas)
-		# note that the integrand here is scaled by exp(lnfi)=fi for the logarithmic transformation of the integrand
-		Yf2 = @. (2π * fi)^order * Hf2 * Af2 * fi
-		# weighted combination of amplitudes with Gauss-Legendre weights
-		int_sum += dfac * dot( wi, Yf2 )
-	end
-    return 2.0 * int_sum
-end
-
-
-@doc raw"""
-	spectral_moments(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
-
-Compute a vector of spectral moments for the specified `order`.
-
-Evaluates the expression:
-```math
-	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
-```
-for each order, where ``k`` is the order of the moment.
-
-Integration is performed using Gauss-Legendre integration using `nodes` nodes and weights.
-The integration domain is partitioned over the `control_freqs` as well as two inserted frequencies at `f_n/1.5` and `f_n*1.5` in order to ensure good approximation of the integral around the `sdof` resonant frequency.
-
-See also: [`spectral_moment`](@ref), [`spectral_moments_gk`](@ref)
-"""
-function spectral_moments(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
-	# pre-allocate for squared fourier amplitude spectrum
-	if S <: Dual
-		Af2 = Vector{S}(undef, nodes)
-		Hf2 = Vector{S}(undef, nodes)
-		int_sumi = zeros(S, length(order))
-	else
-		U = get_parametric_type(fas)
-		Af2 = Vector{U}(undef, nodes)
-		Hf2 = Vector{U}(undef, nodes)
-		int_sumi = zeros(U, length(order))
-	end
-	# partition the integration domain to make sure the integral captures the key change in the integrand
-	f_n = sdof.f_n
- 	# note that we start slightly above zero to avoid a numerical issue with the frequency dependent Q(f) gradients
-	fidLO = findall(control_freqs .< f_n/1.5)
-	fidHI = findall(control_freqs .> f_n*1.5)
-	# perform the integration with a logarithmic transformation
-	lnflims = log.([ control_freqs[fidLO]; f_n/1.5; f_n*1.5; control_freqs[fidHI] ])
-
-	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
-
-	# make sure the orders are listed as increasing for the following loop approach
-	sort!(order)
-	dorder = diff(order)
-
-	for i in 2:lastindex(lnflims)
-		@inbounds dfac = (lnflims[i]-lnflims[i-1])/2
-		@inbounds pfac = (lnflims[i]+lnflims[i-1])/2
-		lnfi = @. dfac * xi + pfac
-		fi = exp.(lnfi)
-		squared_transfer!(Hf2, fi, sdof)
-		squared_fourier_spectrum!(Af2, fi, m, r_ps, fas)
-		# compute default zeroth order integrand amplitude
-		# note that the integrand here is scaled by exp(lnfi)=fi for the logarithmic transformation of the integrand
-		Yf2 = @. Hf2 * Af2 * fi
-
-		for (idx, o) in enumerate(order)
-			if idx == 1
-				Yf2 .*= (2π * fi).^o
-			else
-				@inbounds Yf2 .*= (2π * fi).^(dorder[idx-1])
-			end
-			# weighted combination of amplitudes with Gauss-Legendre weights
-			@inbounds int_sumi[idx] += dfac * dot( wi, Yf2 )
-		end
-	end
-    return 2.0 * int_sumi
-end
-
-
-
-@doc raw"""
-	spectral_moments_gk(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
-
-Compute a vector of spectral moments for the specified `order` using Gauss-Kronrod integration from the `QuadGK.jl` package.
-
-Evaluates the expression:
-```math
-	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
-```
-for each order, where ``k`` is the order of the moment.
-
-Integration is performed using adaptive Gauss-Kronrod integration with the domain split over two intervals from ``[0,f_n]`` and ``[f_n,\infty]`` to ensure that the resonant peak is not missed.
-
-Note that due to the default tolerances, the moments computed by this method are more accurate than those from `spectral_moments` using the Gauss-Legendre approximation. However, this method is also significantly slower, and cannot be used within an automatic differentiation environment.
-
-See also: [`spectral_moment`](@ref), [`spectral_moments`](@ref)
-"""
-function spectral_moments_gk(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
-	int_sumi = zeros(length(order))
-	for (i, o) in enumerate(order)
-		moment_integrand(f) = squared_transfer(f, sdof) * squared_fourier_spectral_ordinate(f, m, r_ps, fas) * (2π*f)^o
-		int_sumi[i] = quadgk(moment_integrand, 0.0, sdof.f_n, Inf)[1]
-	end
-    return 2.0 * int_sumi
-end
-
 
 @doc raw"""
 	zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
@@ -168,9 +18,9 @@ See also: [`zeros_extrema_numbers`](@ref)
 """
 function zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
 	mi = spectral_moments([0, 2, 4], m, r_ps, fas, sdof)
-	m_0 = mi[1]
-	m_2 = mi[2]
-	m_4 = mi[3]
+	m_0 = mi.m0
+	m_2 = mi.m2
+	m_4 = mi.m4
 	fzero = sqrt( m_2 / m_0 ) / (2π)
 	fextrema = sqrt( m_4 / m_2 ) / (2π)
 	return fzero, fextrema
@@ -217,12 +67,19 @@ See also: [`rvt_response_spectral_ordinate`](@ref), [`rvt_response_spectrum`](@r
 """
 function rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
 	# get the duration metrics
-	Drms, Dex, Dratio = rms_duration(m, r_ps, fas, sdof, rvt)
+	Drms, Dex, ~ = rms_duration(m, r_ps, fas, sdof, rvt)
+	# compute the necessary spectral moments
+	if rvt.pf_method == :DK80
+		order = [0, 1, 2]
+	elseif rvt.pf_method == :CL56
+		order = [0, 2, 4]
+	end
+    mi = spectral_moments(order, m, r_ps, fas, sdof)
+
 	# get the rms response
-	m_0 = spectral_moment(0, m, r_ps, fas, sdof)
-	y_rms = sqrt( m_0 / Drms )
-	# get the peak factor
-	pf = peak_factor(m, r_ps, Dex, m_0, fas, sdof, rvt)
+    y_rms = sqrt(mi.m0 / Drms)
+    # get the peak factor
+    pf = peak_factor(Dex, mi, rvt)
 	# response spectral value (in g)
 	Sa = pf * y_rms / 9.80665
 	return Sa

--- a/src/rvt/PJSspectralMoments.jl
+++ b/src/rvt/PJSspectralMoments.jl
@@ -1,0 +1,181 @@
+"""
+	@kwdef struct SpectralMoments{T<:Real}
+
+Struct holding spectral moments `m0` to `m4`
+"""
+@kwdef struct SpectralMoments{T<:Real}
+    m0::T = NaN
+    m1::T = NaN
+    m2::T = NaN
+    m3::T = NaN
+    m4::T = NaN
+end
+
+
+"""
+	create_spectral_moments(order::Vector{Int}, value::Vector{T}) where {T<:Real}
+
+Create a `SpectralMoments` instance from vectors of order integers and moment values.
+Allows for encapsulation of named moments within the returned instance.
+"""
+function create_spectral_moments(order::Vector{Int}, value::Vector{T}) where {T<:Real}
+	dict = Dict{Symbol, T}()
+	for (i, o) in enumerate(order)
+		dict[Symbol("m$o")] = value[i]
+	end
+	return SpectralMoments{T}(; dict...)
+end
+
+
+@doc raw"""
+	spectral_moment(order::Int, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
+
+Compute spectral moment of a specified order.
+
+Evaluates the expression:
+```math
+	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
+```
+where ``k`` is the order of the moment.
+
+Integration is performed using Gauss-Legendre integration using `nodes` nodes and weights.
+The integration domain is partitioned over the `control_freqs` as well as two inserted frequencies at `f_n/1.5` and `f_n*1.5` in order to ensure good approximation of the integral around the `sdof` resonant frequency.
+
+See also: [`spectral_moments`](@ref)
+"""
+function spectral_moment(order::Int, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
+	# pre-allocate for squared fourier amplitude spectrum
+	if S <: Dual
+		Af2 = Vector{S}(undef, nodes)
+		Hf2 = Vector{S}(undef, nodes)
+		int_sum = zero(S)
+	else
+		U = get_parametric_type(fas)
+		Af2 = Vector{U}(undef, nodes)
+		Hf2 = Vector{U}(undef, nodes)
+		int_sum = zero(U)
+	end
+	# partition the integration domain to make sure the integral captures the key change in the integrand
+	f_n = sdof.f_n
+	# note that we start slightly above zero to avoid a numerical issue with the frequency dependent Q(f) gradients
+	fidLO = findall(control_freqs .< f_n/1.5)
+	fidHI = findall(control_freqs .> f_n*1.5)
+	# perform the integration with a logarithmic transformation
+	lnflims = log.([ control_freqs[fidLO]; f_n/1.5; f_n*1.5; control_freqs[fidHI] ])
+
+	# compute the Gauss Legendre nodes and weights
+	xi, wi = gausslegendre(nodes)
+
+	for i in 2:lastindex(lnflims)
+		@inbounds dfac = (lnflims[i]-lnflims[i-1])/2
+		@inbounds pfac = (lnflims[i]+lnflims[i-1])/2
+		lnfi = @. dfac * xi + pfac
+		fi = exp.(lnfi)
+		squared_transfer!(Hf2, fi, sdof)
+		squared_fourier_spectrum!(Af2, fi, m, r_ps, fas)
+		# note that the integrand here is scaled by exp(lnfi)=fi for the logarithmic transformation of the integrand
+		Yf2 = @. (2π * fi)^order * Hf2 * Af2 * fi
+		# weighted combination of amplitudes with Gauss-Legendre weights
+		int_sum += dfac * dot( wi, Yf2 )
+	end
+    # return 2.0 * int_sum
+	return create_spectral_moments([order], [2.0 * int_sum])
+end
+
+
+@doc raw"""
+	spectral_moments(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
+
+Compute a vector of spectral moments for the specified `order`.
+
+Evaluates the expression:
+```math
+	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
+```
+for each order, where ``k`` is the order of the moment.
+
+Integration is performed using Gauss-Legendre integration using `nodes` nodes and weights.
+The integration domain is partitioned over the `control_freqs` as well as two inserted frequencies at `f_n/1.5` and `f_n*1.5` in order to ensure good approximation of the integral around the `sdof` resonant frequency.
+
+See also: [`spectral_moment`](@ref), [`spectral_moments_gk`](@ref)
+"""
+function spectral_moments(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=31, control_freqs::Vector{Float64}=[1e-3, 1e-1, 1.0, 10.0, 100.0, 300.0] ) where {S<:Real,T<:Real}
+	# pre-allocate for squared fourier amplitude spectrum
+	if S <: Dual
+		Af2 = Vector{S}(undef, nodes)
+		Hf2 = Vector{S}(undef, nodes)
+		int_sumi = zeros(S, length(order))
+	else
+		U = get_parametric_type(fas)
+		Af2 = Vector{U}(undef, nodes)
+		Hf2 = Vector{U}(undef, nodes)
+		int_sumi = zeros(U, length(order))
+	end
+	# partition the integration domain to make sure the integral captures the key change in the integrand
+	f_n = sdof.f_n
+ 	# note that we start slightly above zero to avoid a numerical issue with the frequency dependent Q(f) gradients
+	fidLO = findall(control_freqs .< f_n/1.5)
+	fidHI = findall(control_freqs .> f_n*1.5)
+	# perform the integration with a logarithmic transformation
+	lnflims = log.([ control_freqs[fidLO]; f_n/1.5; f_n*1.5; control_freqs[fidHI] ])
+
+	# compute the Gauss Legendre nodes and weights
+	xi, wi = gausslegendre(nodes)
+
+	# make sure the orders are listed as increasing for the following loop approach
+	sort!(order)
+	dorder = diff(order)
+
+	for i in 2:lastindex(lnflims)
+		@inbounds dfac = (lnflims[i]-lnflims[i-1])/2
+		@inbounds pfac = (lnflims[i]+lnflims[i-1])/2
+		lnfi = @. dfac * xi + pfac
+		fi = exp.(lnfi)
+		squared_transfer!(Hf2, fi, sdof)
+		squared_fourier_spectrum!(Af2, fi, m, r_ps, fas)
+		# compute default zeroth order integrand amplitude
+		# note that the integrand here is scaled by exp(lnfi)=fi for the logarithmic transformation of the integrand
+		Yf2 = @. Hf2 * Af2 * fi
+
+		for (idx, o) in enumerate(order)
+			if idx == 1
+				Yf2 .*= (2π * fi).^o
+			else
+				@inbounds Yf2 .*= (2π * fi).^(dorder[idx-1])
+			end
+			# weighted combination of amplitudes with Gauss-Legendre weights
+			@inbounds int_sumi[idx] += dfac * dot( wi, Yf2 )
+		end
+	end
+    # return 2.0 * int_sumi
+    return create_spectral_moments(order, 2.0 * int_sumi)
+end
+
+
+
+@doc raw"""
+	spectral_moments_gk(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
+
+Compute a vector of spectral moments for the specified `order` using Gauss-Kronrod integration from the `QuadGK.jl` package.
+
+Evaluates the expression:
+```math
+	m_k = 2\int_{0}^{\infty} \left(2\pi f\right)^k |H(f;f_n,\zeta_n)|^2 |A(f)|^2 df
+```
+for each order, where ``k`` is the order of the moment.
+
+Integration is performed using adaptive Gauss-Kronrod integration with the domain split over two intervals from ``[0,f_n]`` and ``[f_n,\infty]`` to ensure that the resonant peak is not missed.
+
+Note that due to the default tolerances, the moments computed by this method are more accurate than those from `spectral_moments` using the Gauss-Legendre approximation. However, this method is also significantly slower, and cannot be used within an automatic differentiation environment.
+
+See also: [`spectral_moment`](@ref), [`spectral_moments`](@ref)
+"""
+function spectral_moments_gk(order::Vector{Int}, m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
+	int_sumi = zeros(length(order))
+	for (i, o) in enumerate(order)
+		moment_integrand(f) = squared_transfer(f, sdof) * squared_fourier_spectral_ordinate(f, m, r_ps, fas) * (2π*f)^o
+		int_sumi[i] = quadgk(moment_integrand, 0.0, sdof.f_n, Inf)[1]
+	end
+    # return 2.0 * int_sumi
+    return create_spectral_moments(order, 2.0 * int_sumi)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1818,6 +1818,13 @@ using LinearAlgebra
             @test Sab1p0 > Sab1p5
             @test Sab1p5 < Sab1p0
 
+            rvt = RandomVibrationParameters(:CL56)
+            Sab1p0 = rvt_response_spectral_ordinate(T, m, r_ps, fasb1p0, rvt)
+            Sab1p5 = rvt_response_spectral_ordinate(T, m, r_ps, fasb1p5, rvt)
+
+            @test Sab1p0 > Sab1p5
+            @test Sab1p5 < Sab1p0
+
 
             # @code_warntype rvt_response_spectrum(Ti, m, r_psf, fasf, rvt)
             # @code_warntype rvt_response_spectrum(Ti, m, r_psd, fasd, rvt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1816,6 +1816,7 @@ using LinearAlgebra
             Sab1p5 = rvt_response_spectral_ordinate(T, m, r_ps, fasb1p5, rvt)
 
             @test Sab1p0 > Sab1p5
+            @test Sab1p5 < Sab1p0
 
 
             # @code_warntype rvt_response_spectrum(Ti, m, r_psf, fasf, rvt)


### PR DESCRIPTION
Changes made with a view to illuminating duplicate calls to functions within spectral moment and peak factor computations. Basically pre-compute the spectral moments and pass these to the relevant functions rather than deciding which moments to evaluate within the peak_factor dispatch