### PR TITLE
Use internal pre-computation of Gauss Legendre nodes and weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /test/scratch.jl
 Manifest.toml
 /docs/Manifest.toml
+gmt.history
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.jl.mem
 /docs/build/
 /test/scratch.jl
-Manifest.jl
+Manifest.toml
+/docs/Manifest.toml

--- a/src/rvt/PJSpeakFactor.jl
+++ b/src/rvt/PJSpeakFactor.jl
@@ -1,6 +1,6 @@
 
 @doc raw"""
-	peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=35) where {S<:Real,T<:Real}
+	peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {S<:Real,T<:Real}
 
 Peak factor computed using the Cartwright and Longuet-Higgins (1956) formulation.
 
@@ -14,7 +14,7 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_dk80`](@ref)
 """
-function peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=35) where {S<:Real,T<:Real}
+function peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {S<:Real,T<:Real}
 	# get the numbers of zero crossing and extrema
 	rvt = RandomVibrationParameters(:CL56)
 	n_z, n_e = zeros_extrema_numbers(m, r_ps, fas, sdof, rvt)
@@ -22,7 +22,9 @@ function peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 	ξ = n_z / n_e
 
 	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
+    if nodes != length(glxi)
+        glxi, glwi = gausslegendre(nodes)
+    end
 
 	z_min = 0.0
 	z_max = 8.0
@@ -30,19 +32,19 @@ function peak_factor_cl56(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 	pfac = (z_max+z_min)/2
 
 	# scale the nodes to the appropriate range
-	zi = @. dfac * xi + pfac
+	zi = @. dfac * glxi + pfac
 
 	# define the integrand
 	integrand(z) = 1.0 - (1.0 - ξ*exp(-z^2))^n_e
 
-	int_sum = dfac * dot( wi, integrand.(zi) )
+	int_sum = dfac * dot( glwi, integrand.(zi) )
 
 	return sqrt(2.0) * int_sum
 end
 
 
 @doc raw"""
-	peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:Real}
+	peak_factor_cl56(Dex::U, mi::SpectralMoments; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {U<:Real}
 
 Peak factor computed using the Cartwright and Longuet-Higgins (1956) formulation, using pre-computed `Dex` and `m0` values.
 
@@ -56,7 +58,7 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_dk80`](@ref)
 """
-function peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:Real}
+function peak_factor_cl56(Dex::U, mi::SpectralMoments; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {U<:Real}
 	# get all necessary spectral moments
 	m0 = mi.m0
 	m2 = mi.m2
@@ -68,7 +70,9 @@ function peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:
 	ξ = n_z / n_e
 
 	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
+    if nodes != length(glxi)
+        glxi, glwi = gausslegendre(nodes)
+    end
 
 	z_min = 0.0
 	z_max = 8.0
@@ -76,19 +80,19 @@ function peak_factor_cl56(Dex::U, mi::SpectralMoments; nodes::Int=35) where {U<:
 	pfac = (z_max+z_min)/2
 
 	# scale the nodes to the appropriate range
-	zi = @. dfac * xi + pfac
+	zi = @. dfac * glxi + pfac
 
 	# define the integrand
 	integrand(z) = 1.0 - (1.0 - ξ*exp(-z^2))^n_e
 
-	int_sum = dfac * dot( wi, integrand.(zi) )
+	int_sum = dfac * dot( glwi, integrand.(zi) )
 
 	return sqrt(2.0) * int_sum
 end
 
 
 @doc raw"""
-	peak_factor_cl56(n_z::T, n_e::T; nodes::Int=35) where T<:Real
+	peak_factor_cl56(n_z::T, n_e::T; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where T<:Real
 
 Peak factor computed using the Cartwright and Longuet-Higgins (1956) formulation, using pre-computed `n_z` and `n_e` values.
 
@@ -102,12 +106,14 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_dk80`](@ref)
 """
-function peak_factor_cl56(n_z::T, n_e::T; nodes::Int=35) where T<:Real
+function peak_factor_cl56(n_z::T, n_e::T; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where T<:Real
 	# get the ratio of zero crossings to extrema
 	ξ = n_z / n_e
 
 	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
+    if nodes != length(glxi)
+        glxi, glwi = gausslegendre(nodes)
+    end
 
 	z_min = 0.0
 	z_max = 8.0
@@ -115,12 +121,12 @@ function peak_factor_cl56(n_z::T, n_e::T; nodes::Int=35) where T<:Real
 	pfac = (z_max+z_min)/2
 
 	# scale the nodes to the appropriate range
-	zi = @. dfac * xi + pfac
+	zi = @. dfac * glxi + pfac
 
 	# define the integrand
 	integrand(z) = 1.0 - (1.0 - ξ*exp(-z^2))^n_e
 
-	int_sum = dfac * dot( wi, integrand.(zi) )
+	int_sum = dfac * dot( glwi, integrand.(zi) )
 
 	pf = sqrt(2.0) * int_sum
 	return pf
@@ -197,7 +203,7 @@ end
 
 
 @doc raw"""
-	peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=30) where {S<:Real,T<:Real}
+	peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {S<:Real,T<:Real}
 
 Peak factor computed using the Der Kiureghian (1980)/Vanmarcke (1975) formulation.
 
@@ -219,7 +225,7 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_cl56`](@ref)
 """
-function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; nodes::Int=30) where {S<:Real,T<:Real}
+function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {S<:Real,T<:Real}
 	# compute first three spectral moments
 	mi = spectral_moments([0, 1, 2], m, r_ps, fas, sdof)
 	m0 = mi.m0
@@ -236,7 +242,9 @@ function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 	n_z = Dex * sqrt( m2/m0 ) / π
 
 	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
+    if nodes != length(glxi)
+        glxi, glwi = gausslegendre(nodes)
+    end
 
 	z_min = 0.0
 	z_max = 6.0
@@ -244,16 +252,16 @@ function peak_factor_dk80(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillato
 	pfac = (z_max+z_min)/2
 
 	# scale the nodes to the appropriate range
-	zi = @. dfac * xi + pfac
+	zi = @. dfac * glxi + pfac
 	# evaluate integrand
 	yy = vanmarcke_ccdf.(zi, n_z, δeff)
 
-	return dfac * dot( wi, yy )
+	return dfac * dot( glwi, yy )
 end
 
 
 @doc raw"""
-	peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:Real}
+	peak_factor_dk80(Dex::U, mi::SpectralMoments; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {U<:Real}
 
 Peak factor computed using the Der Kiureghian (1980)/Vanmarcke (1975) formulation, using precomputed `Dex` and `m0`.
 
@@ -275,7 +283,7 @@ The integral is evaluated using Gauss-Legendre integration -- and is suitable fo
 
 See also: [`peak_factor`](@ref), [`peak_factor_cl56`](@ref)
 """
-function peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:Real}
+function peak_factor_dk80(Dex::U, mi::SpectralMoments; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {U<:Real}
 	# compute first three spectral moments
 	m0 = mi.m0
 	m1 = mi.m1
@@ -289,7 +297,9 @@ function peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:
 	n_z = Dex * sqrt( m2/m0 ) / π
 
 	# compute the Gauss Legendre nodes and weights
-	xi, wi = gausslegendre(nodes)
+    if nodes != length(glxi)
+        glxi, glwi = gausslegendre(nodes)
+    end
 
 	z_min = 0.0
 	z_max = 6.0
@@ -297,11 +307,11 @@ function peak_factor_dk80(Dex::U, mi::SpectralMoments; nodes::Int=30) where {U<:
 	pfac = (z_max+z_min)/2
 
 	# scale the nodes to the appropriate range
-	zi = @. dfac * xi + pfac
+	zi = @. dfac * glxi + pfac
 	# evaluate integrand
 	yy = vanmarcke_ccdf.(zi, n_z, δeff)
 
-	return dfac * dot( wi, yy )
+	return dfac * dot( glwi, yy )
 end
 
 
@@ -354,7 +364,7 @@ end
 
 
 @doc raw"""
-	peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
+	peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {S<:Real,T<:Real}
 
 Peak factor ``u_{max} / u_{rms}`` with a switch of `pf_method` to determine the approach adopted.
 `rvt.pf_method` can currently be one of:
@@ -363,11 +373,11 @@ Peak factor ``u_{max} / u_{rms}`` with a switch of `pf_method` to determine the 
 
 Defaults to `:DK80`.
 """
-function peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
+function peak_factor(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
 	if rvt.pf_method == :CL56
-		return peak_factor_cl56(m, r_ps, fas, sdof)
+		return peak_factor_cl56(m, r_ps, fas, sdof, glxi=glxi, glwi=glwi)
 	elseif rvt.pf_method == :DK80
-		return peak_factor_dk80(m, r_ps, fas, sdof)
+		return peak_factor_dk80(m, r_ps, fas, sdof, glxi=glxi, glwi=glwi)
 	else
 		U = get_parametric_type(fas)
 		return U(NaN)
@@ -376,7 +386,7 @@ end
 
 
 """
-	peak_factor(Dex::U, m0::V, rvt::RandomVibrationParameters) where {U<:Real}
+	peak_factor(Dex::U, m0::V, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i, nodes::Int=length(glxi)) where {U<:Real}
 
 Peak factor u_max / u_rms with a switch of `pf_method` to determine the approach adopted.
 `pf_method` can currently be one of:
@@ -385,11 +395,11 @@ Peak factor u_max / u_rms with a switch of `pf_method` to determine the approach
 
 Defaults to `:DK80`.
 """
-function peak_factor(Dex::U, mi::SpectralMoments, rvt::RandomVibrationParameters) where {U<:Real}
+function peak_factor(Dex::U, mi::SpectralMoments, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {U<:Real}
 	if rvt.pf_method == :CL56
-		return peak_factor_cl56(Dex, mi)
+		return peak_factor_cl56(Dex, mi, glxi=glxi, glwi=glwi)
 	elseif rvt.pf_method == :DK80
-		return peak_factor_dk80(Dex, mi)
+		return peak_factor_dk80(Dex, mi, glxi=glxi, glwi=glwi)
 	else
 		return U(NaN)
 	end

--- a/src/rvt/PJSrandomVibration.jl
+++ b/src/rvt/PJSrandomVibration.jl
@@ -1,7 +1,9 @@
 
+const xn31i, wn31i = gausslegendre(31)
+
 
 @doc raw"""
-	zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
+	zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
 
 Defines the frequencies of extrema and zero-crossings using moments ``m_0``, ``m_2`` and ``m_4``. Returns a tuple of ``(f_z,f_e)``.
 
@@ -16,8 +18,8 @@ f_{e} = \frac{1}{2\pi}\sqrt{\frac{m_4}{m_2}}
 
 See also: [`zeros_extrema_numbers`](@ref)
 """
-function zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator) where {S<:Real,T<:Real}
-	mi = spectral_moments([0, 2, 4], m, r_ps, fas, sdof)
+function zeros_extrema_frequencies(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
+	mi = spectral_moments([0, 2, 4], m, r_ps, fas, sdof, glxi=glxi, glwi=glwi)
 	m_0 = mi.m0
 	m_2 = mi.m2
 	m_4 = mi.m4
@@ -44,8 +46,8 @@ In both cases, the excitaion duration, ``D_{ex}`` is computed from the `excitati
 
 See also: [`zeros_extrema_frequencies`](@ref), [`excitation_duration`](@ref)
 """
-function zeros_extrema_numbers(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
-    fz, fe = zeros_extrema_frequencies(m, r_ps, fas, sdof)
+function zeros_extrema_numbers(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
+    fz, fe = zeros_extrema_frequencies(m, r_ps, fas, sdof, glxi=glxi, glwi=glwi)
     Dex = excitation_duration(m, r_ps, fas, rvt)
     return 2fz*Dex, 2fe*Dex
 end
@@ -53,7 +55,7 @@ end
 
 
 @doc raw"""
-	rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
+	rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
 
 Response spectral ordinate (units of ``g``) for the specified scenario.
 
@@ -65,7 +67,7 @@ where ``\psi`` is the peak factor computed from `peak_factor`, ``m_0`` is the ze
 
 See also: [`rvt_response_spectral_ordinate`](@ref), [`rvt_response_spectrum`](@ref), [`rvt_response_spectrum!`](@ref)
 """
-function rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters) where {S<:Real,T<:Real}
+function rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, sdof::Oscillator, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real}
 	# get the duration metrics
 	Drms, Dex, ~ = rms_duration(m, r_ps, fas, sdof, rvt)
 	# compute the necessary spectral moments
@@ -74,12 +76,12 @@ function rvt_response_spectral_ordinate(m::S, r_ps::T, fas::FourierParameters, s
 	elseif rvt.pf_method == :CL56
 		order = [0, 2, 4]
 	end
-    mi = spectral_moments(order, m, r_ps, fas, sdof)
+    mi = spectral_moments(order, m, r_ps, fas, sdof, glxi=glxi, glwi=glwi)
 
 	# get the rms response
     y_rms = sqrt(mi.m0 / Drms)
     # get the peak factor
-    pf = peak_factor(Dex, mi, rvt)
+    pf = peak_factor(Dex, mi, rvt, glxi=glxi, glwi=glwi)
 	# response spectral value (in g)
 	Sa = pf * y_rms / 9.80665
 	return Sa
@@ -87,7 +89,7 @@ end
 
 
 @doc raw"""
-	rvt_response_spectral_ordinate(period::U, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Float64}
+	rvt_response_spectral_ordinate(period::U, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real,U<:Float64}
 
 Response spectral ordinate (units of ``g``) for the specified scenario.
 
@@ -99,16 +101,16 @@ where ``\psi`` is the peak factor computed from `peak_factor`, ``m_0`` is the ze
 
 See also: [`rvt_response_spectral_ordinate`](@ref), [`rvt_response_spectrum`](@ref), [`rvt_response_spectrum!`](@ref)
 """
-function rvt_response_spectral_ordinate(period::U, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Float64}
+function rvt_response_spectral_ordinate(period::U, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real,U<:Float64}
   	# create a sdof instance
   	sdof = Oscillator(1.0/period)
-	return rvt_response_spectral_ordinate(m, r_ps, fas, sdof, rvt)
+	return rvt_response_spectral_ordinate(m, r_ps, fas, sdof, rvt, glxi=glxi, glwi=glwi)
 end
 
 
 
 @doc raw"""
-	rvt_response_spectrum(period::Vector{U}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Float64}
+	rvt_response_spectrum(period::Vector{U}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real,U<:Float64}
 
 Response spectrum (units of ``g``) for the vector of periods `period` and the specified scenario.
 
@@ -120,7 +122,7 @@ where ``\psi`` is the peak factor computed from `peak_factor`, ``m_0`` is the ze
 
 See also: [`rvt_response_spectral_ordinate`](@ref), [`rvt_response_spectrum!`](@ref)
 """
-function rvt_response_spectrum(period::Vector{U}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Float64}
+function rvt_response_spectrum(period::Vector{U}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real,U<:Float64}
 	if S <: Dual
 		Sa = zeros(S,length(period))
 	else
@@ -128,7 +130,7 @@ function rvt_response_spectrum(period::Vector{U}, m::S, r_ps::T, fas::FourierPar
 		Sa = zeros(V,length(period))
 	end
 	for i in 1:length(period)
-		@inbounds Sa[i] = rvt_response_spectral_ordinate(period[i], m, r_ps, fas, rvt)
+		@inbounds Sa[i] = rvt_response_spectral_ordinate(period[i], m, r_ps, fas, rvt, glxi=glxi, glwi=glwi)
   	end
   	return Sa
 end
@@ -147,8 +149,8 @@ where ``\psi`` is the peak factor computed from `peak_factor`, ``m_0`` is the ze
 
 See also: [`rvt_response_spectral_ordinate`](@ref), [`rvt_response_spectrum!`](@ref)
 """
-function rvt_response_spectrum!(Sa::Vector{U}, period::Vector{V}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters) where {S<:Real,T<:Real,U<:Real,V<:Float64}
+function rvt_response_spectrum!(Sa::Vector{U}, period::Vector{V}, m::S, r_ps::T, fas::FourierParameters, rvt::RandomVibrationParameters; glxi::Vector{Float64}=xn31i, glwi::Vector{Float64}=wn31i) where {S<:Real,T<:Real,U<:Real,V<:Float64}
 	for i in 1:length(period)
-		@inbounds Sa[i] = rvt_response_spectral_ordinate(period[i], m, r_ps, fas, rvt)
+		@inbounds Sa[i] = rvt_response_spectral_ordinate(period[i], m, r_ps, fas, rvt, glxi=glxi, glwi=glwi)
   	end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2030,27 +2030,27 @@ using StaticArrays
             @test isnan(pf)
             pf = peak_factor(Dexf, m0d, rvt)
             @test isnan(pf)
-
-            m0f = spectral_moments([0, 1, 2, 3, 4], m, r_ps, fasf, sdof)
-            m0d = spectral_moments([0, 1, 2, 3, 4], Dual(m), r_ps, fasf, sdof)
-            pf = peak_factor(Dexf, m0f, rvt)
-            @test isnan(pf)
-            pf = peak_factor(Dexd, m0d, rvt)
-            @test isnan(pf)
-            pf = peak_factor(Dexf, m0d, rvt)
-            @test isnan(pf)
             rvt = RandomVibrationParameters(:CL56)
             pf = peak_factor(Dexf, m0f, rvt)
             @test isnan(pf)
             # @test pf ≈ peak_factor(m, r_ps, fasf, sdof, RandomVibrationParameters(:CL56))
 
+            m0f = spectral_moments([0, 1, 2, 3, 4], m, r_ps, fasf, sdof)
+            m0d = spectral_moments([0, 1, 2, 3, 4], Dual(m), r_ps, fasf, sdof)
+            pff = peak_factor(Dexf, m0f, rvt)
+            pfd = peak_factor(Dexd, m0d, rvt)
+            pfm = peak_factor(Dexf, m0d, rvt)
+            @test pff ≈ pfd.value
+            @test pff ≈ pfm.value
+
             pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(0.0, 10.0, 10.0)
             @test pfi ≈ 1.0
             pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(Inf, 10.0, 10.0)
             @test pfi ≈ 0.0
-            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(0.0, 10.0, 10.0, nodes=50)
+
+            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(0.0, 10.0, 10.0)
             @test pfi ≈ 1.0
-            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(Inf, 10.0, 10.0, nodes=50)
+            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(Inf, 10.0, 10.0)
             @test pfi ≈ 0.0
 
             pf0 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, 10.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1848,6 +1848,13 @@ using StaticArrays
             @test m0f.m0 ≈ m0d.m0.value
             @test m0d.m0 ≈ m0m.m0
 
+            order = 0
+            m0f = spectral_moment(order, m, r_psf, fasf, sdof, nodes=50)
+            m0d = spectral_moment(order, m, r_psd, fasd, sdof, nodes=50)
+            m0m = spectral_moment(order, m, r_psm, fasm, sdof, nodes=50)
+            @test m0f.m0 ≈ m0d.m0.value
+            @test m0d.m0 ≈ m0m.m0
+
             # @code_warntype spectral_moment(order, m, r_psf, fasf, sdof)
             # @code_warntype spectral_moment(order, m, r_psd, fasd, sdof)
             # @code_warntype spectral_moment(order, m, r_psm, fasm, sdof)
@@ -1868,6 +1875,15 @@ using StaticArrays
             @test smi.m2 ≈ smigk.m2 rtol=1e-3
             @test smi.m3 ≈ smigk.m3 rtol=1e-3
             @test smi.m4 ≈ smigk.m4 rtol=1e-3
+
+            smi = spectral_moments([0, 1, 2, 3, 4], m, r_psf, fasf, sdof, nodes=50)
+            smigk = StochasticGroundMotionSimulation.spectral_moments_gk([0, 1, 2, 3, 4], m, r_psf, fasf, sdof)
+
+            @test smi.m0 ≈ smigk.m0 rtol = 1e-5
+            @test smi.m1 ≈ smigk.m1 rtol = 1e-5
+            @test smi.m2 ≈ smigk.m2 rtol = 1e-5
+            @test smi.m3 ≈ smigk.m3 rtol = 1e-5
+            @test smi.m4 ≈ smigk.m4 rtol = 1e-5
 
 
             sdof = Oscillator(1 / 3)
@@ -2014,6 +2030,15 @@ using StaticArrays
             @test isnan(pf)
             pf = peak_factor(Dexf, m0d, rvt)
             @test isnan(pf)
+
+            m0f = spectral_moments([0, 1, 2, 3, 4], m, r_ps, fasf, sdof)
+            m0d = spectral_moments([0, 1, 2, 3, 4], Dual(m), r_ps, fasf, sdof)
+            pf = peak_factor(Dexf, m0f, rvt)
+            @test isnan(pf)
+            pf = peak_factor(Dexd, m0d, rvt)
+            @test isnan(pf)
+            pf = peak_factor(Dexf, m0d, rvt)
+            @test isnan(pf)
             rvt = RandomVibrationParameters(:CL56)
             pf = peak_factor(Dexf, m0f, rvt)
             @test isnan(pf)
@@ -2022,6 +2047,10 @@ using StaticArrays
             pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(0.0, 10.0, 10.0)
             @test pfi ≈ 1.0
             pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(Inf, 10.0, 10.0)
+            @test pfi ≈ 0.0
+            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(0.0, 10.0, 10.0, nodes=50)
+            @test pfi ≈ 1.0
+            pfi = StochasticGroundMotionSimulation.peak_factor_integrand_cl56(Inf, 10.0, 10.0, nodes=50)
             @test pfi ≈ 0.0
 
             pf0 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, 10.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2026,7 +2026,7 @@ using StaticArrays
 
             pf0 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, 10.0)
             pf1 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, 10.0, nodes=50)
-            @test pf0 ≈ pf1
+            @test pf0 ≈ pf1 rtol=1e-7
 
             rvt = RandomVibrationParameters(:DK80)
             @test rvt.dur_rms == :BT15

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2057,6 +2057,14 @@ using StaticArrays
             pf1 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, 10.0, nodes=50)
             @test pf0 ≈ pf1 rtol=1e-7
 
+            pf2 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, m0f)
+            pf3 = StochasticGroundMotionSimulation.peak_factor_cl56(10.0, m0f, nodes=50)
+            @test pf2 ≈ pf3 rtol=1e-6
+
+            pf4 = StochasticGroundMotionSimulation.peak_factor_dk80(10.0, m0f)
+            pf5 = StochasticGroundMotionSimulation.peak_factor_dk80(10.0, m0f, nodes=50)
+            @test pf4 ≈ pf5 rtol = 1e-7
+
             rvt = RandomVibrationParameters(:DK80)
             @test rvt.dur_rms == :BT15
 


### PR DESCRIPTION
Previously the nodes and weights for the spectral moment and peak factor integrals were computed on the fly for each respective function call. Now, move those to module variables and only compute if necessary. Should speed up the overall computations by a decent amount (and definitely removes duplicated computations).